### PR TITLE
fix: preserve congress/chamber/state_abbrev for unmatched rows

### DIFF
--- a/R/extractNamesPerCongress.R
+++ b/R/extractNamesPerCongress.R
@@ -106,9 +106,19 @@ extractNamesPerCongress <- function(congress_i, data, members, col_name, congres
 
   data <- tidyr::unnest(data, {{member_row_match_col}}, keep_empty = TRUE)
 
+  # Save original values for columns that will be overwritten by members
+  orig_congress <- data$congress
+  orig_chamber <- data$chamber
+  orig_state_abbrev <- data$state_abbrev
+
   #Merge found units in members
   data <- dplyr::bind_cols(data[!names(data) %in% names(members)],
                            members[data[[member_row_match_col]],])
+
+  # Restore original values for unmatched rows (where member row is NA)
+  data$congress <- dplyr::coalesce(data$congress, orig_congress)
+  data$chamber <- dplyr::coalesce(data$chamber, orig_chamber)
+  data$state_abbrev <- dplyr::coalesce(data$state_abbrev, orig_state_abbrev)
 
   data[[member_row_match_col]] <- NULL
 


### PR DESCRIPTION
## Problem

When `extractMemberName()` fails to match a row to any legislator, the `congress`, `chamber`, and `state_abbrev` columns are set to `NA` in the output. This makes it difficult to debug failed matches, as noted in #9.

## Root cause

In `extractNamesPerCongress()`, the `bind_cols()` call at line 110-111 drops the original `congress`, `chamber`, and `state_abbrev` columns from `data` (because they overlap with `members`), then replaces them with values from `members[data[[member_row_match_col]],]`. For unmatched rows where `member_row_match_col` is `NA`, `members[NA,]` returns a row of `NA`s.

## Fix

Save the original values before `bind_cols()` and restore them for unmatched rows using `dplyr::coalesce()`:

```r
orig_congress <- data$congress
orig_chamber <- data$chamber
orig_state_abbrev <- data$state_abbrev

data <- dplyr::bind_cols(data[!names(data) %in% names(members)],
                         members[data[[member_row_match_col]],])

data$congress <- dplyr::coalesce(data$congress, orig_congress)
data$chamber <- dplyr::coalesce(data$chamber, orig_chamber)
data$state_abbrev <- dplyr::coalesce(data$state_abbrev, orig_state_abbrev)
```

## Validation

- `R CMD build` succeeds
- `R CMD check --no-manual --no-vignettes` passes (only pre-existing WARNING about `bioguide_id` typo in `members.Rd`)
- No new NOTEs or ERRORs introduced

Fixes #9